### PR TITLE
bug : refresh Token 재발급 절차 변경.

### DIFF
--- a/src/main/java/spharos/msg/domain/users/controller/AuthController.java
+++ b/src/main/java/spharos/msg/domain/users/controller/AuthController.java
@@ -1,10 +1,10 @@
 package spharos.msg.domain.users.controller;
 
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import spharos.msg.domain.users.dto.request.ChangePasswordRequestDto;
 import spharos.msg.domain.users.dto.request.DuplicationCheckRequestDto;
@@ -25,7 +25,6 @@ public class AuthController {
 
     private final AuthService authService;
 
-    //회원가입
     @Operation(summary = "통합회원가입", description = "통합회원 회원가입")
     @PostMapping("/signup")
     public ApiResponse<?> signUpUnion(
@@ -34,7 +33,6 @@ public class AuthController {
         return ApiResponse.of(SuccessStatus.SIGN_UP_SUCCESS_UNION, null);
     }
 
-    //로그인
     @Operation(summary = "로그인", description = "통합회원 로그인")
     @PostMapping("/login")
     public ApiResponse<LoginOutDto> loginUnion(
@@ -44,7 +42,6 @@ public class AuthController {
         return ApiResponse.of(SuccessStatus.LOGIN_SUCCESS_UNION, login);
     }
 
-    //로그아웃
     @Operation(summary = "로그아웃", description = "로그인 회원 로그아웃")
     @DeleteMapping("/logout/{userId}")
     public ApiResponse<?> logout(
@@ -54,17 +51,15 @@ public class AuthController {
         return ApiResponse.of(SuccessStatus.LOGOUT_SUCCESS, null);
     }
 
-    //토큰 재발급
     @Operation(summary = "Reissue Token", description = "Access Token 재발급")
     @GetMapping("/reissue")
     public ApiResponse<?> reissueToken(
-            @AuthenticationPrincipal UserDetails userDetails
+            @RequestHeader(AUTHORIZATION) String refreshToken
     ) {
-        ReissueOutDto reissueOutDto = authService.reissueToken(userDetails.getUsername());
+        ReissueOutDto reissueOutDto = authService.reissueToken(refreshToken);
         return ApiResponse.of(SuccessStatus.TOKEN_REISSUE_COMPLETE, reissueOutDto);
     }
 
-    //아이디 중복 확인
     @Operation(summary = "아이디 중복확인", description = "입력받은 아이디의 중복 여부를 확인합니다.")
     @PostMapping("/check-duplicate-id")
     public ApiResponse<?> duplicateCheckLoginId(


### PR DESCRIPTION
#107 
기존) 하나의 Refresh Token으로 expired 될떄까지 여러번 발급 가능
변경) RefreshToken으로 재발급 시, 해당 Refresh Token 재사용 안되게 처리

## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
